### PR TITLE
Fix relative path resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ gradle.afterProject {
 	def url = new URL(
 			"https://raw.githubusercontent.com/TheRandomLabs/Common-Gradle/$branch/.editorconfig"
 	)
-	def file = new File(".editorconfig")
+	def file = file(".editorconfig")
 
 	url.withInputStream { input ->
 		file.withOutputStream {

--- a/forge.gradle
+++ b/forge.gradle
@@ -12,7 +12,7 @@ ext {
 	//For some reason, ForgeGradle doesn't like it when this is true.
 	autoUpdateLicenses = false
 	registerDefaultMavenPublication = false
-	autoConfigTOMLClassesDir = new File("build/autoconfig-toml")
+	autoConfigTOMLClassesDir = file("build/autoconfig-toml")
 }
 
 apply from: "https://raw.githubusercontent.com/TheRandomLabs/Common-Gradle/$branch/build.gradle"


### PR DESCRIPTION
PR for the exact same reason as https://github.com/TechReborn/TechReborn/pull/2390, `new File(relativePath)` isn't guaranteed to base off of the project directory and it seems to break when using IntelliJ IDEA 2021.1, on Windows at least.

I haven't tested these particular changes, but they should work just fine.